### PR TITLE
增加仅在首字母为特定字符时开启快速选择的功能

### DIFF
--- a/lua/select_character.lua
+++ b/lua/select_character.lua
@@ -41,8 +41,12 @@ local function select_character(key, env)
    local config = engine.schema.config
    local first_key = config:get_string('key_binder/select_first_character') or 'bracketleft'
    local last_key = config:get_string('key_binder/select_last_character') or 'bracketright'
+   local initials = config:get_string('key_binder/select_character_only_for_initial') or ''
 
    if (key:repr() == first_key and commit_text ~= "") then
+      if (initials ~= '' and not string.find(initials, context.input:sub(1,1))) then
+         return 2
+      end
       engine:commit_text(first_character(commit_text))
       context:clear()
 
@@ -50,6 +54,9 @@ local function select_character(key, env)
    end
 
    if (key:repr() == last_key and commit_text ~= "") then
+      if (initials ~= '' and not string.find(initials, context.input:sub(1,1))) then
+         return 2
+      end
       engine:commit_text(last_character(commit_text))
       context:clear()
 


### PR DESCRIPTION
仅在输入首字符存在于 `key_binder/select_character_only_for_initial` 配置的字符串时开启快速选择功能。

在使用特殊符号（例如`、/、\ ）作为反查起始时可以做到暂时关闭功能以输入快速选择所占用的字符（例如方括号、句点和逗号）